### PR TITLE
Build containers automatically every week

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,36 @@
+name: Containers
+on:
+#  schedule:
+##   Build every week on Monday 00:00
+#    - cron:  '0 0 * * 1'
+  pull_request:
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: [ ovirt-provider-ovn-tests ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install podman
+      - name: Build container images
+        working-directory: automation/containers
+        run: make ${{ matrix.container }}
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: almusil
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: quay.io
+      - name: Push to Quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ovirt/${{ matrix.container }}
+          tags: centos-8 centos-9
+          registry: quay.io
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
ovirt-provider-ovn project has three containers,
it is worth to build them and push every week
to update at least the unerlaying OS.

Signed-off-by: Ales Musil <amusil@redhat.com>